### PR TITLE
Added simc functionality that doesn't depend on html reports or discord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.json
+htmldir
+hmtldir/*
+simc_install
+simc_install/*
 __pycache__

--- a/simc.py
+++ b/simc.py
@@ -6,7 +6,7 @@ import aiohttp
 import asyncio
 import time
 import json
-import simc_utils
+from simc_utils import *
 from urllib.parse import quote
 
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
@@ -26,10 +26,10 @@ htmldir = simc_opts['htmldir']
 website = simc_opts['website']
 os.makedirs(os.path.dirname(os.path.join(htmldir + 'debug', 'test.file')), exist_ok=True)
 
-def sim_noreport(realm, char, scale, data, addon, region, iterations, fightstyle,
-                 enemy, length, l_fixed, api_key, threads, process_priority, executable):
+async def sim_noreport(realm, char, scale, data, addon, region, iterations, fightstyle,  
+                 enemy, length, l_fixed, api_key, threads, process_priority, executable, message):
     await bot.send_message(message.channel, 'Simulating: Starting...')
-    result_str = sim_nohtml(realm, char, scale, data, addon, region, iterations, fightstyle,
+    result_str = await sim_nohtml(realm, char, scale, data, addon, region, iterations, fightstyle,
                  enemy, length, l_fixed, api_key, threads, process_priority, executable)
     await bot.send_message(message.channel, trim_report_string(result_str))
     await bot.change_presence(status=discord.Status.online, game=discord.Game(name='Sim: Ready'))
@@ -270,7 +270,7 @@ async def on_message(message):
                     else:
                         bot.loop.create_task(sim_noreport(realm, char, scale, data, addon, region,
                                                              iterations, fightstyle, enemy, length, l_fixed, 
-                                                             api_key, threads, process_priority, executable))
+                                                             api_key, threads, process_priority, simc_opts['executable'], message))
 
 
 @bot.event

--- a/simc.py
+++ b/simc.py
@@ -26,6 +26,13 @@ htmldir = simc_opts['htmldir']
 website = simc_opts['website']
 os.makedirs(os.path.dirname(os.path.join(htmldir + 'debug', 'test.file')), exist_ok=True)
 
+def sim_noreport(realm, char, scale, data, addon, region, iterations, fightstyle,
+                 enemy, length, l_fixed, api_key, threads, process_priority, executable):
+    await bot.send_message(message.channel, 'Simulating: Starting...')
+    result_str = sim_nohtml(realm, char, scale, data, addon, region, iterations, fightstyle,
+                 enemy, length, l_fixed, api_key, threads, process_priority, executable)
+    await bot.send_message(message.channel, trim_report_string(result_str))
+    await bot.change_presence(status=discord.Status.online, game=discord.Game(name='Sim: Ready'))
 
 def check_simc():
     null = open(os.devnull, 'w')
@@ -127,6 +134,7 @@ async def on_message(message):
     addon = ''
     aoe = 'no'
     enemy = ''
+    giveReport = True
     fightstyle = simc_opts['fightstyles'][0]
     movements = ''
     length = simc_opts['length']
@@ -182,6 +190,9 @@ async def on_message(message):
                         elif args[i].startswith(('a ', 'aoe ')):
                             temp = args[i].split()
                             aoe = temp[1]
+                        #Does not create HTML report, just text with playername + DPS
+                        elif args[i].startswith(('n ','noreport ')):
+                            giveReport = False
                         elif args[i].startswith(('l ', 'length ')):
                             temp = args[i].split()
                             length = temp[1]
@@ -251,10 +262,15 @@ async def on_message(message):
                           'Iterations: %s\nScaling: %s\nData: %s' % (realm.capitalize(), char.capitalize(), movements,
                                                                      length, aoe.capitalize(), iterations,
                                                                      scaling.capitalize(), data.capitalize())
-                    filename = '%s-%s' % (char, timestr)
                     await bot.send_message(message.channel, msg)
-                    bot.loop.create_task(sim(realm, char, scale, filename, data, addon, region, iterations, fightstyle,
-                                             enemy, length, l_fixed, api_key, message))
+                    if giveReport:
+                        filename = '%s-%s' % (char, timestr)
+                        bot.loop.create_task(sim(realm, char, scale, filename, data, addon, region, iterations, fightstyle,
+                                                 enemy, length, l_fixed, api_key, message))
+                    else:
+                        bot.loop.create_task(sim_noreport(realm, char, scale, data, addon, region,
+                                                             iterations, fightstyle, enemy, length, l_fixed, 
+                                                             api_key, threads, process_priority, executable))
 
 
 @bot.event

--- a/simc_tests.py
+++ b/simc_tests.py
@@ -35,10 +35,43 @@ async def test_gear_api():
 		print("%s: %s" % (i, items[i]['name']))
 	return gear
 
+async def test_sim_api():
+	os.chdir(os.path.dirname(os.path.abspath(__file__)))
+	with open('user_data.json') as data_file:
+		user_opt = json.load(data_file)
+	simc_opts = user_opt['simcraft_opt'][0]
+	api_key = simc_opts['api_key']
+	realm = simc_opts['default_realm']
+	region = simc_opts['region']
+	iterations = simc_opts['default_iterations']
+	timestr = time.strftime("%Y%m%d-%H%M%S")
+	scale = 0
+	scaling = 'no'
+	data = 'armory'
+	char = 'Splaytree'
+	addon = ''
+	aoe = 'no'
+	enemy = ''
+	fightstyle = simc_opts['fightstyles'][0]
+	movements = ''
+	length = simc_opts['length']
+	l_fixed = 0
+	threads = os.cpu_count()
+	if 'threads' in simc_opts:
+		threads = simc_opts['threads']
+		process_priority = 'below_normal'
+	if 'process_priority' in simc_opts:
+		process_priority = simc_opts['process_priority']
+	executable = simc_opts['executable']
+	simresult = await sim_nohtml(realm, char, scale, data, 
+    	addon, region, iterations, fightstyle, enemy, length, 
+    	l_fixed, api_key, threads, process_priority, executable)
+	print(trim_report_string(simresult))
+
 
 #async io loop
 loop = asyncio.get_event_loop()
 loop.run_until_complete(test_role_api())
 loop.run_until_complete(test_gear_api())
+loop.run_until_complete(test_sim_api())
 loop.close()
-

--- a/simc_utils.py
+++ b/simc_utils.py
@@ -5,13 +5,13 @@ import aiohttp
 import asyncio
 import time
 import json
+import re
 from urllib.parse import quote
 
 #
 # A utils file for simc that is not dependent on Discord
 # For testing functionality
 #
-
 
 ## Returns the role of the character, e.g. 'DPS'
 async def check_role(region, realm, char, api_key):
@@ -41,3 +41,35 @@ async def check_gear(region, realm, char, api_key):
             data = await response.json()
             return data
 
+## Return sim for the character, but without html report. Differences from main sim function:
+##removed 'message' argument
+##added 'threads' argument
+##added 'process_priority' argument
+##added executable
+async def sim_nohtml(realm, char, scale, data, addon, region, iterations, fightstyle, enemy, length, l_fixed,
+              api_key, threads, process_priority, executable):
+    loop = True
+    scale_stats = 'agility,strength,intellect,crit_rating,haste_rating,mastery_rating,versatility_rating'
+    options = 'calculate_scale_factors=%s scale_only=%s threads=%s iterations=%s ' \
+              'fight_style=%s enemy=%s apikey=%s process_priority=%s max_time=%s' % (scale, scale_stats, threads, iterations,
+                                                                                     fightstyle, enemy, api_key,
+                                                                                     process_priority, length)
+    if data == 'addon':
+        options += ' input=%s' % addon
+    else:
+        options += ' armory=%s,%s,%s' % (region, realm, char)
+
+    if l_fixed == 1:
+        options += ' vary_combat_length=0.0 fixed_time=1'
+
+    command_inner = "%s %s" % (executable, options)
+    proc = subprocess.Popen(command_inner.split(" "), stdout=subprocess.PIPE)
+    result_str = proc.stdout.read().decode() #decodes as ascii
+    proc.terminate()
+    return result_str
+
+#Trims the report to only include the player information and their DPS
+def trim_report_string(result_str):
+    playerLine = re.search('Player:.*\n',result_str).group()
+    dps = re.search('DPS:.*\n', result_str).group()
+    return (playerLine + dps)


### PR DESCRIPTION
Added a flag to just print a players DPS without doing a full HTML report, -n or -noreport, with a new simc function that doesn't depend on discord. Did _NOT_ test the changes to the main simc driver since we don't have a discord bot setup